### PR TITLE
Fix protocol implementation for PLR 50C

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,120 @@
-# Bosch PLR Demo
+# Bosch PLR/GLM Web Bluetooth Demo
 
-This is a demo implementation for communicating with Bosch laser range finders through web Bluetooth. The device used for this demo is a Bosch PLR 50c. Please note that this demo has not been tested with other PLR or Bosch GLM laser range finders.
+A Web Bluetooth demo for communicating with Bosch PLR and GLM laser rangefinders. Tested with the **Bosch PLR 50C**.
 
-Relevant documentation from the Bosch GLM/PLR Bluetooth App Kit can be found in the docs folder. The full development kit is available at [Bosch GLM/PLR Bluetooth App Kit](https://developer.bosch.com/products-and-services/sdks/bosch-glm-plr-app-kit).
+> **Browser support:** Web Bluetooth API is currently supported in Chrome and Edge only.
 
-As of now, the Web Bluetooth API is only supported in Chrome and Edge. However, support may be extended to other browsers in the future. [Live Demo](https://html-preview.github.io/?url=https://github.com/PointerEvent/bosch-plr-demo/blob/main/app/index.html)
+## Features
+
+- **Connect/disconnect** via Web Bluetooth
+- **Trigger distance measurements** from the browser with configurable reference edge (back, front, side)
+- **AutoSync** — automatically receive all measurements triggered on the device (distance, angle, area, volume)
+- **Full protocol parsing** — CRC-8 validation, long/short frame handling, 16-byte measurement blocks
+- **Measurement types** — distance, continuous, area, volume, angle with correct units (m, m², m³, °)
+- **Side measurements** — area and volume results include individual side values
+- **Live UI** — real-time measurement display, history table, raw BLE frame log
+- **Device info** — battery level, temperature, laser status from measurement data
+- **Command explorer** — send raw hex commands to explore the device protocol
+
+## PLR 50C Protocol Notes
+
+The PLR 50C has limited BLE command support:
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Distance measurement | Works | `CMD 0x40` with edge byte |
+| AutoSync | Works | `CMD 0x55` with `[0x01, 0x00]` — receives all measurement types |
+| Mode change | Not supported | Device acknowledges but ignores. Change mode on the device. |
+| Laser on/off | Not supported | Device acknowledges but ignores |
+| Backlight | Not supported | Device acknowledges but ignores |
+| Beep | Not supported | Device acknowledges but ignores |
+
+### AutoSync Measurement Block (16 bytes)
+
+When a measurement is triggered on the device, it sends a 16-byte block via `CMD_EXCHANGE_DATA` (0x55):
+
+| Offset | Size | Content |
+|--------|------|---------|
+| 0 | 1 | DevModeRef: mode (bits 2-7), reference edge (bits 0-1) |
+| 1 | 1 | DevStatus: metric (bit 3), low battery (bit 2), temp warning (bit 1), laser (bit 0) |
+| 2-3 | 2 | UniqueID (uint16 LE) |
+| 4-7 | 4 | Result (float32 LE) |
+| 8-11 | 4 | Component 1 (float32 LE) — intermediate side or first side |
+| 12-15 | 4 | Component 2 (float32 LE) — second side (area) or unused |
+
+### Mode IDs (from DevModeRef >> 2)
+
+| ID | Type | Notes |
+|----|------|-------|
+| 1 | Distance | Single measurement |
+| 2 | Continuous | Continuous measurement |
+| 3 | Area (partial) | Intermediate step — component1 = measured side |
+| 4 | Area | Final result — component1 = side 1, component2 = side 2 |
+| 5 | Volume (partial) | Intermediate step — component1 = measured side |
+| 6 | Volume (partial) | Intermediate step — component1 = measured side |
+| 7 | Volume | Final result — component1 = last side |
+| 8 | Angle | Inclination in degrees |
+
+### Distance Measurement Response (4 bytes)
+
+Response to `CMD_MEASURE` (0x40): `uint32 LE` in units of 0.05mm.
+
+Example: `0x00007C9E` = 31902 × 0.05 = 1595.1mm = **1.595m**
+
+## Project Structure
+
+```
+app/
+├── index.html          # Demo UI
+└── js/
+    ├── protocol.js     # MT Protocol: constants, CRC-8, frame parsing
+    └── device.js       # BoschDevice class: connection, commands, events
+docs/
+├── MT_connectivity_protocol_1_2_9.pdf
+└── MT_connectivity_protocol_LRF_command_set_2_5_0.pdf
+```
+
+## BLE Identifiers
+
+| Element | UUID |
+|---------|------|
+| Service | `00005301-0000-0041-5253-534F46540000` |
+| Characteristic | `00004301-0000-0041-5253-534F46540000` |
+
+> The PLR 50C exposes a single characteristic for both read (notifications) and write.
+
+## Frame Format
+
+```
+[mode] [command?] [length] [data...] [crc8]
+```
+
+- **Mode byte** — frame type (bits 6-7: `11`=request, `00`=response) and format (bits 0-1: `00`=long, `01`=short)
+- **CRC-8** — polynomial `0xA6`, init value `0xAA`
+
+## Running Locally
+
+Serve the `app/` directory:
+
+```bash
+# Python
+python3 -m http.server 8080 --directory app
+
+# PHP
+php -S localhost:8080 -t app
+```
+
+Open `http://localhost:8080` in Chrome or Edge.
+
+> On `localhost`, Chrome allows Web Bluetooth without HTTPS.
+
+## Official Documentation
+
+The `docs/` folder contains protocol specifications from the Bosch GLM/PLR Bluetooth App Kit:
+- `MT_connectivity_protocol_1_2_9.pdf` — Transport layer protocol
+- `MT_connectivity_protocol_LRF_command_set_2_5_0.pdf` — LRF command set
+
+## Related Projects
+
+- [piannucci/pymtprotocol](https://github.com/piannucci/pymtprotocol) — Python MT protocol implementation for Bosch GLM100
+- [philipptrenz/BOSCH-GLM-rangefinder](https://github.com/philipptrenz/BOSCH-GLM-rangefinder) — Python script for Bosch GLM 100C (archived)

--- a/app/index.html
+++ b/app/index.html
@@ -1,365 +1,596 @@
-<html>
-  <head>
-    <title>BUSH</title>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bosch PLR/GLM Web Bluetooth Demo</title>
     <style>
-      body {
-        font-family: "Helvetica", sans-serif;
-        background-color: #0f171f;
-        color: #e5e5e5;
-      }
-      table {
-        margin-top: 1em;
-      }
-      table th {
-        text-align: left;
-        padding-right: 0.5em;
-      }
-      button {
-        background-color: #dedede;
-        color: #121212;
-        text-transform: capitalize;
-        border-radius: 0.2em;
-        border: none;
-        padding: 0.3em 0.7em;
-        font-weight: bold;
-      }
-      button:hover {
-        background-color: #f5f5f5;
-        cursor: pointer;
-      }
-      h1,
-      h2,
-      h3,
-      h4 {
-        color: #eeeeee;
-      }
-      #device-measurements,
-      #triggered-measurements {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.5em;
-      }
-      .warning {
-        background-color: #c93939;
-        color: #f5f5f5;
-        padding: 2em;
-        border-radius: 0.2em;
-        margin-bottom: 1em;
-        display: none;
-      }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, sans-serif;
+            background-color: #0f171f;
+            color: #e5e5e5;
+            padding: 1.5em;
+            max-width: 800px;
+            margin: 0 auto;
+        }
+        h1 { font-size: 1.5em; margin-bottom: 0.25em; }
+        h2 { font-size: 1.1em; margin: 1.5em 0 0.5em; color: #9ca3af; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600; }
+        p { color: #9ca3af; font-size: 0.9em; margin-bottom: 1em; }
+        a { color: #60a5fa; }
+
+        button {
+            background-color: #374151;
+            color: #e5e5e5;
+            border: 1px solid #4b5563;
+            border-radius: 0.375em;
+            padding: 0.5em 1em;
+            font-size: 0.875em;
+            font-weight: 500;
+            cursor: pointer;
+            transition: background-color 0.15s;
+        }
+        button:hover:not(:disabled) { background-color: #4b5563; }
+        button:disabled { opacity: 0.4; cursor: not-allowed; }
+        button.primary { background-color: #2563eb; border-color: #3b82f6; }
+        button.primary:hover:not(:disabled) { background-color: #1d4ed8; }
+        button.danger { background-color: #dc2626; border-color: #ef4444; }
+        button.danger:hover:not(:disabled) { background-color: #b91c1c; }
+        button.success { background-color: #059669; border-color: #10b981; }
+        button.success:hover:not(:disabled) { background-color: #047857; }
+
+        .card {
+            background-color: #1f2937;
+            border: 1px solid #374151;
+            border-radius: 0.5em;
+            padding: 1em;
+            margin-bottom: 1em;
+        }
+
+        .connection-bar { display: flex; align-items: center; gap: 1em; flex-wrap: wrap; }
+        .status-dot {
+            width: 10px; height: 10px;
+            border-radius: 50%;
+            background-color: #6b7280;
+            display: inline-block;
+        }
+        .status-dot.connecting { background-color: #f59e0b; animation: pulse 1s infinite; }
+        .status-dot.connected { background-color: #10b981; }
+        .status-dot.error { background-color: #ef4444; }
+        @keyframes pulse { 50% { opacity: 0.5; } }
+        .status-text { font-size: 0.875em; color: #9ca3af; }
+
+        .device-info { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 0.75em; }
+        .info-item label { display: block; font-size: 0.75em; color: #6b7280; text-transform: uppercase; letter-spacing: 0.05em; }
+        .info-item span { font-size: 0.95em; font-variant-numeric: tabular-nums; }
+
+        .controls { display: flex; gap: 0.5em; flex-wrap: wrap; align-items: flex-end; }
+        .control-group { display: flex; flex-direction: column; gap: 0.25em; }
+        .control-group-label { font-size: 0.7em; color: #6b7280; text-transform: uppercase; letter-spacing: 0.05em; }
+
+        select {
+            background-color: #374151;
+            color: #e5e5e5;
+            border: 1px solid #4b5563;
+            border-radius: 0.375em;
+            padding: 0.5em 0.75em;
+            font-size: 0.875em;
+        }
+
+        .measurement-result {
+            font-size: 2.5em;
+            font-weight: 700;
+            font-variant-numeric: tabular-nums;
+            text-align: center;
+            padding: 0.5em;
+            color: #60a5fa;
+        }
+        .measurement-result .unit { font-size: 0.4em; color: #6b7280; font-weight: 400; }
+        .measurement-details {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+            gap: 0.5em;
+            font-size: 0.85em;
+        }
+        .measurement-details .detail label { display: block; font-size: 0.75em; color: #6b7280; }
+        .measurement-details .detail span { font-variant-numeric: tabular-nums; }
+
+        .measurement-list { max-height: 300px; overflow-y: auto; font-size: 0.85em; }
+        .measurement-list table { width: 100%; border-collapse: collapse; }
+        .measurement-list th { text-align: left; color: #6b7280; font-weight: 500; font-size: 0.8em; text-transform: uppercase; padding: 0.5em; border-bottom: 1px solid #374151; }
+        .measurement-list td { padding: 0.4em 0.5em; border-bottom: 1px solid #1f2937; font-variant-numeric: tabular-nums; }
+        .measurement-list tr:hover td { background-color: #1f2937; }
+
+        .raw-log {
+            max-height: 200px;
+            overflow-y: auto;
+            font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, monospace;
+            font-size: 0.75em;
+            line-height: 1.6;
+            color: #6b7280;
+        }
+        .raw-log .rx { color: #34d399; }
+        .raw-log .tx { color: #fbbf24; }
+        .raw-log .err { color: #f87171; }
+
+        .warning {
+            background-color: #7f1d1d;
+            border: 1px solid #dc2626;
+            color: #fca5a5;
+            padding: 1em;
+            border-radius: 0.5em;
+            margin-bottom: 1em;
+            display: none;
+        }
+
+        input[type="text"] {
+            background-color: #374151;
+            color: #e5e5e5;
+            border: 1px solid #4b5563;
+            border-radius: 0.375em;
+            padding: 0.5em 0.75em;
+            font-size: 0.875em;
+            font-family: "SF Mono", "Fira Code", monospace;
+        }
+        .cmd-preset { font-size: 0.7em !important; padding: 0.3em 0.6em !important; }
+
+        .hidden { display: none !important; }
     </style>
-    <script>
-      window.onload = function () {
-        if (!navigator.bluetooth) {
-          document.querySelector(".warning").style.display = "block";
-        }
-      };
-    </script>
-  </head>
-  <body>
-    <div class="warning">
-      <i>Navigator: bluetooth</i> is not supported in your browser. Currently,
-      it is only supported in Chrome and Edge.
-    </div>
-    <h1>PLR 50C demo</h1>
+</head>
+<body>
+    <h1>Bosch PLR/GLM Web Bluetooth Demo</h1>
     <p>
-      This demo uses the Bosch PLR 50C. Other Bosch laser range finders might
-      work as well but aren't tested.
+        Connect to a Bosch PLR 50C or GLM laser rangefinder via Web Bluetooth.
+        Requires Chrome or Edge with Web Bluetooth support.
     </p>
-    <p>Check console for logs.</p>
-    <button id="connect-btn">Connect Device</button>
-    <table id="device-info">
-      <tr>
-        <th>Device ID</th>
-        <td>-</td>
-      </tr>
-      <tr>
-        <th>Name</th>
-        <td>-</td>
-      </tr>
-      <tr>
-        <th>Gatt Connected</th>
-        <td>-</td>
-      </tr>
-      <tr>
-        <th>Timestamp</th>
-        <td>-</td>
-      </tr>
-    </table>
-    <div>
-      <h2>Connected Controlls</h2>
-      <div>
-        <button id="beep-btn">Beep</button>
-        <button id="measure-btn">Trigger measurement</button>
-        <button id="laser-on">Blink Laser</button>
-      </div>
-      <h4>Triggered Measurements (raw data)</h4>
-      <div id="triggered-measurements"></div>
+
+    <div class="warning" id="warning">
+        Web Bluetooth API is not available in this browser. Please use Chrome or Edge.
     </div>
-    <div>
-      <h2>Device measurements</h2>
-      <div id="device-measurements"></div>
+
+    <!-- Connection -->
+    <div class="card">
+        <div class="connection-bar">
+            <button id="connect-btn" class="primary">Connect Device</button>
+            <button id="disconnect-btn" class="danger hidden">Disconnect</button>
+            <span class="status-dot" id="status-dot"></span>
+            <span class="status-text" id="status-text">Not connected</span>
+        </div>
     </div>
-    <script>
-      let service;
-      let bluetoothGattServer; // {connected: true, device: BluetoothDevice, …}
-      let characteristic;
 
-      document
-        .getElementById("connect-btn")
-        .addEventListener("click", function (event) {
-          // primary service UUID
-          const glmServiceUuid = "00005301-0000-0041-5253-534f46540000";
-          const characteristicUuid = "00004301-0000-0041-5253-534f46540000";
+    <!-- Device Info -->
+    <div class="card hidden" id="device-info-card">
+        <h2>Device</h2>
+        <div class="device-info">
+            <div class="info-item">
+                <label>Name</label>
+                <span id="info-name">—</span>
+            </div>
+            <div class="info-item">
+                <label>Battery</label>
+                <span id="info-battery">—</span>
+            </div>
+            <div class="info-item">
+                <label>Temperature</label>
+                <span id="info-temperature">—</span>
+            </div>
+            <div class="info-item">
+                <label>Laser</label>
+                <span id="info-laser">—</span>
+            </div>
+        </div>
+    </div>
 
-          // filters used to filter out devices that are not Bosch PLR devices
-          const filters = [
-            { namePrefix: "Bosch PLR" },
-            { services: [glmServiceUuid] },
-          ];
+    <!-- Controls -->
+    <div class="card hidden" id="controls-card">
+        <h2>Measure</h2>
+        <div class="controls">
+            <div class="control-group">
+                <span class="control-group-label">Edge</span>
+                <select id="edge-select">
+                    <option value="0">Front (0x00)</option>
+                    <option value="128" selected>Rear (0x80)</option>
+                    <option value="192">Tripod (0xC0)</option>
+                </select>
+            </div>
+            <div class="control-group">
+                <button id="measure-btn" class="success">Measure Distance</button>
+            </div>
+            <div class="control-group">
+                <span class="control-group-label">Laser</span>
+                <button id="laser-on-btn">Flash</button>
+            </div>
+            <div class="control-group">
+                <span class="control-group-label">Beep</span>
+                <button id="beep-btn">Beep</button>
+            </div>
+            <div class="control-group">
+                <span class="control-group-label">Backlight</span>
+                <div style="display:flex; gap:0.25em;">
+                    <button id="backlight-on-btn">On</button>
+                    <button id="backlight-off-btn">Off</button>
+                </div>
+            </div>
+        </div>
+        <p style="margin-top: 0.75em; font-size: 0.8em;">
+            For angle, area, or volume, change mode on the device — results sync automatically.
+        </p>
+    </div>
 
-          navigator.bluetooth
-            .requestDevice({
-              filters,
-              optionalServices: [characteristicUuid],
-            })
-            .then((device) => {
-              console.log("Device connected: " + device.name);
-              setDeviceInfo(device);
-              return device.gatt.connect();
-            })
-            .then((server) => {
-              bluetoothGattServer = server;
-              console.log("Connected to GATT server");
-              setInfoGattConnected(server.connected);
+    <!-- Last Measurement -->
+    <div class="card hidden" id="measurement-card">
+        <h2>Last Measurement</h2>
+        <div class="measurement-result" id="measurement-result">—</div>
+        <div class="measurement-details" id="measurement-details"></div>
+    </div>
 
-              // get primary service and then the characteristic
-              return bluetoothGattServer
-                .getPrimaryService(glmServiceUuid)
-                .then((s) => {
-                  service = s;
-                  return s.getCharacteristic(characteristicUuid);
-                });
-            })
-            .then((c) => {
-              console.log("Characteristic found");
-              characteristic = c;
+    <!-- Measurement History -->
+    <div class="card hidden" id="history-card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2 style="margin: 0;">History</h2>
+            <button id="clear-history-btn" style="font-size: 0.75em;">Clear</button>
+        </div>
+        <div class="measurement-list">
+            <table>
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th>Source</th>
+                        <th>Type</th>
+                        <th>Result</th>
+                        <th>Time</th>
+                    </tr>
+                </thead>
+                <tbody id="history-body"></tbody>
+            </table>
+        </div>
+    </div>
 
-              // we need to enable indications to allow the device to send data without being polled
-              // startNotifications() enables indications as well as notifications
-              return c.startNotifications();
-            })
-            .then(() => {
-              // "AutoSyncEnable" command, sets the device to send data when a measurement is
-              // triggered on the device
-              const data = new Uint8Array([0xc0, 0x55, 0x02, 0x01, 0x00, 0x1a]);
-              return characteristic.writeValue(data);
-            })
-            .then(() => {
-              // add listener for events (indications) triggered by device
-              characteristic.addEventListener(
-                "characteristicvaluechanged",
-                indicationEvent
-              );
-            })
-            .then(() => {
-              console.log("Server, service, characteristic ready", {
-                bluetoothGattServer,
-                service,
-                characteristic,
-              });
-              // a beep when we are done connecting
-              return beep();
-            })
-            .catch((error) => {
-              console.error("An error occurred: ", error);
-            });
+    <!-- Command Explorer -->
+    <div class="card hidden" id="explorer-card">
+        <h2>Command Explorer</h2>
+        <div class="controls" style="margin-bottom: 0.75em;">
+            <div class="control-group">
+                <span class="control-group-label">Command (hex)</span>
+                <input type="text" id="cmd-hex" value="40" placeholder="e.g. 40" style="width: 4em;">
+            </div>
+            <div class="control-group">
+                <span class="control-group-label">Payload (hex bytes)</span>
+                <input type="text" id="cmd-payload" placeholder="e.g. 00" style="width: 10em;">
+            </div>
+            <div class="control-group">
+                <button id="cmd-send-btn">Send</button>
+            </div>
+        </div>
+        <div style="margin-top: 0.75em; display: flex; gap: 0.5em; flex-wrap: wrap;">
+            <button id="scan-cmd-btn">Scan command</button>
+            <input type="text" id="scan-cmd" value="40" placeholder="cmd hex" style="width: 3em;">
+            <span style="font-size: 0.8em; color: #6b7280; align-self: center;">payload 0x00→0xFF, 300ms delay</span>
+            <button id="scan-stop-btn" class="danger hidden">Stop</button>
+        </div>
+        <pre id="scan-results" style="margin-top: 0.5em; font-size: 0.75em; color: #9ca3af; max-height: 300px; overflow-y: auto;"></pre>
+        <p style="font-size: 0.8em; color: #6b7280; margin-top: 0.75em;">Send raw commands to explore the device protocol. Watch the Raw BLE Log for responses.</p>
+    </div>
+
+    <!-- Raw Log -->
+    <div class="card">
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+            <h2 style="margin: 0;">Raw BLE Log</h2>
+            <button id="clear-log-btn" style="font-size: 0.75em;">Clear</button>
+        </div>
+        <div class="raw-log" id="raw-log"></div>
+    </div>
+
+    <script type="module">
+        import { BoschDevice } from './js/device.js';
+
+        let measurementCount = 0;
+        const $ = (id) => document.getElementById(id);
+
+        const connectBtn = $('connect-btn');
+        const disconnectBtn = $('disconnect-btn');
+        const statusDot = $('status-dot');
+        const statusText = $('status-text');
+        const measurementResult = $('measurement-result');
+        const measurementDetails = $('measurement-details');
+        const historyBody = $('history-body');
+        const rawLog = $('raw-log');
+
+        function getUnit(type) {
+            if (type === 'Angle') return '°';
+            if (type === 'Area') return 'm²';
+            if (type === 'Volume') return 'm³';
+            return 'm';
+        }
+
+        const device = new BoschDevice({
+            onStatusChange(state, message) {
+                statusDot.className = `status-dot ${state}`;
+                statusText.textContent = message;
+
+                const connected = state === 'connected';
+                connectBtn.classList.toggle('hidden', connected);
+                disconnectBtn.classList.toggle('hidden', !connected);
+                $('device-info-card').classList.toggle('hidden', !connected);
+                $('controls-card').classList.toggle('hidden', !connected);
+                $('explorer-card').classList.toggle('hidden', !connected);
+
+                if (connected) $('info-name').textContent = message;
+                if (state === 'disconnected') connectBtn.disabled = false;
+            },
+
+            onMeasurement(data) {
+                $('measurement-card').classList.remove('hidden');
+                $('history-card').classList.remove('hidden');
+
+                const isPartial = data.measurementType?.includes('partial');
+                const value = isPartial ? (data.component1 ?? 0) : (data.result ?? 0);
+                const type = data.measurementType || '—';
+                const unit = getUnit(type);
+
+                // Side measurements for area/volume final results
+                const sides = [];
+                if (!isPartial) {
+                    if (data.component1 && data.component1 !== 0) sides.push(data.component1);
+                    if (data.component2 && data.component2 !== 0) sides.push(data.component2);
+                }
+
+                measurementResult.innerHTML = `${value.toFixed(3)} <span class="unit">${unit}</span>`;
+
+                // Details
+                const details = [];
+                if (type) details.push(['Type', type]);
+                if (data.distanceReference) details.push(['Reference', data.distanceReference]);
+                if (data.source) details.push(['Source', data.source]);
+                if (data.battery !== undefined) details.push(['Battery', `${data.battery}%`]);
+                if (data.temperature !== undefined) details.push(['Temp', `${data.temperature}°C`]);
+                if (data.angle !== undefined && data.angle !== 0) details.push(['Angle', `${data.angle.toFixed(1)}°`]);
+                if (data.compassHeading !== undefined && data.compassHeading !== 0) details.push(['Compass', `${data.compassHeading}°`]);
+                if (sides.length > 0) details.push(['Sides', sides.map(s => `${s.toFixed(3)} m`).join(' × ')]);
+                if (data.uniqueId !== undefined) details.push(['ID', `0x${data.uniqueId.toString(16)}`]);
+                if (data.lowBattery) details.push(['Warning', 'Low battery']);
+                if (data.temperatureWarning) details.push(['Warning', 'Temperature']);
+
+                measurementDetails.innerHTML = details.map(
+                    ([label, val]) => `<div class="detail"><label>${label}</label><span>${val}</span></div>`
+                ).join('');
+
+                // History
+                measurementCount++;
+                const row = document.createElement('tr');
+                row.innerHTML = `
+                    <td>${measurementCount}</td>
+                    <td>${data.source || '—'}</td>
+                    <td>${type}</td>
+                    <td>${value.toFixed(3)} ${unit}${sides.length ? ` (${sides.map(s => s.toFixed(3)).join(' × ')})` : ''}</td>
+                    <td>${new Date().toLocaleTimeString()}</td>
+                `;
+                historyBody.prepend(row);
+
+                // Update device info
+                if (data.battery !== undefined) $('info-battery').textContent = `${data.battery}%`;
+                if (data.temperature !== undefined) $('info-temperature').textContent = `${data.temperature}°C`;
+                if (data.laserOn !== undefined) $('info-laser').textContent = data.laserOn ? 'On' : 'Off';
+
+            },
+
+            onStatus(status) {
+                const cls = status.isSuccess ? 'rx' : 'err';
+                log(`Status: ${status.statusMessage}${status.hardwareError ? ' [HW Error]' : ''}${status.notReady ? ' [Not Ready]' : ''}`, cls);
+            },
+
+            onRawFrame(message, hex) {
+                log(`RX: ${hex}`, 'rx');
+            },
         });
 
-      document.getElementById("beep-btn").addEventListener("click", longBeep);
+        // --- Event listeners ---
 
-      document.getElementById("measure-btn").addEventListener("click", () => {
-        console.log("send: measure");
-        // measure
-        return characteristic.writeValue(
-          new Uint8Array([0xc0, 0x40, 0x01, 0x00, 0xfa])
-        );
-      });
-      document.getElementById("laser-on").addEventListener("click", () => {
-        console.log("send: laser on");
-        // laser on
-        return characteristic.writeValue(
-          new Uint8Array([0xc0, 0x41, 0x00, 0x96])
-        );
-      });
-
-      function setDeviceInfo(device) {
-        let tableCells = document.querySelectorAll("#device-info td");
-
-        tableCells[0].innerHTML = device.id;
-        tableCells[1].innerHTML = device.name;
-        tableCells[2].innerHTML = device.gatt.connected;
-        tableCells[3].innerHTML = new Date().toISOString();
-      }
-
-      function setInfoGattConnected(gattConnected) {
-        let tableCells = document.querySelectorAll("#device-info td");
-        tableCells[2].innerHTML = gattConnected;
-      }
-
-      function beep() {
-        console.log("send: beep on, beep off");
-
-        // turn beeper on
-        return characteristic
-          .writeValue(new Uint8Array([0xc0, 0x45, 0x00, 0xd0]))
-          .then(() => {
-            // turn beeper off
-            return characteristic.writeValue(
-              new Uint8Array([0xc0, 0x46, 0x00, 0x58])
-            );
-          });
-      }
-
-      function longBeep() {
-        console.log("Send: beep on, beep off");
-        // turn beeper on
-        return characteristic
-          .writeValue(new Uint8Array([0xc0, 0x45, 0x00, 0xd0]))
-          .then(() => {
-            return new Promise((resolve) => {
-              setTimeout(() => {
-                characteristic
-                  .writeValue(new Uint8Array([0xc0, 0x46, 0x00, 0x58]))
-                  .then(resolve);
-              }, 750);
-            });
-          });
-      }
-
-      function indicationEvent(event) {
-        // event.target.value is a DataView containing the characteristic's new value
-        let message = event.target.value;
-
-        // Join the hexadecimal strings into a single string
-        // to display the full command in a human-readable format
-        let hexString = dataViewToString(message);
-
-        if (hexString === "000082") {
-          console.log("Receive:", "OK");
-        } else if (hexString.startsWith("c055")) {
-          // mode: 0xc0, request-command: 0x55
-          // 0x55 is command 85 which is "Exchange data container"
-          // this example assumes it is a distance measurement triggered
-          // from the device, other commands are not accounted for
-          // check MT_connectivity_protocol_LRF_command_set_2_5_0.pdf for more
-          console.log("Receive:", "Exchange Data Container");
-          parseExchangeDataContainer(message, hexString);
-        } else if (hexString.length === 14 && hexString.startsWith("0004")) {
-          // assume it is a measurement triggered from browser
-          console.log("Receive:", "Short Form Message");
-
-          // TODO: parse these into actual measurements
-          document.getElementById("triggered-measurements").innerHTML += `<span>
-			${hexString}</span>`;
-        } else {
-          console.log("Receive:", "Unknown", hexString);
-        }
-      }
-
-    function parseExchangeDataContainer(message, hexString) {
-        // Extract the mode, request-command, data length, data, and checksum
-        let mode = hexString.slice(0, 2);
-        let requestCommand = hexString.slice(2, 4);
-        let dataLengthHex = hexString.slice(4, 6);
-        let dataLength = parseInt(dataLengthHex, 16);
-        let data = dataLength === 0 ? {} : extractData(message, 3, dataLength);
-        let checksum = hexString.slice(-2); // TODO: verification of the checksum (CRC8)
-
-        console.log("Message:", {
-          RawMessage: message,
-          MessageAsHexString: hexString,
-          SplitIntoParts: {
-            mode,
-            requestCommand,
-                dataLengthHex,
-                dataLength,
-            checksum,
-          },
-            dataHex: hexString.slice(6, 6 + 2 * dataLength),
-            data
+        connectBtn.addEventListener('click', async () => {
+            connectBtn.disabled = true;
+            try {
+                await device.connect();
+            } catch (err) {
+                statusDot.className = 'status-dot error';
+                statusText.textContent = err.message || 'Connection failed';
+                connectBtn.disabled = false;
+            }
         });
 
-        let measurementSpan = document.getElementById("device-measurements");
-        measurementSpan.innerHTML += `<span>
-		  ${data.result.toFixed(3)}</span>`;
-    }
+        disconnectBtn.addEventListener('click', () => device.disconnect());
 
-    function extractData(message, start, length)
-    {
-        if (length < 16) {
-            console.error("Data length is too short");
-            return {};
+        $('measure-btn').addEventListener('click', async () => {
+            try {
+                const edge = parseInt($('edge-select').value);
+                await device.measure(edge);
+                log(`TX: measure(edge=${edge})`, 'tx');
+            } catch (err) {
+                log(`Error: ${err.message}`, 'err');
+            }
+        });
+
+        $('laser-on-btn').addEventListener('click', async () => {
+            try {
+                await device.laserOn();
+                log('TX: laserOn', 'tx');
+            } catch (err) {
+                log(`Error: ${err.message}`, 'err');
+            }
+        });
+
+        $('beep-btn').addEventListener('click', async () => {
+            try {
+                await device.beep(500);
+                log('TX: beep', 'tx');
+            } catch (err) {
+                log(`Error: ${err.message}`, 'err');
+            }
+        });
+
+        $('backlight-on-btn').addEventListener('click', async () => {
+            try {
+                await device.backlightOn();
+                log('TX: backlightOn', 'tx');
+            } catch (err) {
+                log(`Error: ${err.message}`, 'err');
+            }
+        });
+
+        $('backlight-off-btn').addEventListener('click', async () => {
+            try {
+                await device.backlightOff();
+                log('TX: backlightOff', 'tx');
+            } catch (err) {
+                log(`Error: ${err.message}`, 'err');
+            }
+        });
+
+        // Command Explorer
+        function parseHexBytes(str) {
+            const clean = str.replace(/\s+/g, '');
+            if (!clean) return null;
+            const bytes = [];
+            for (let i = 0; i < clean.length; i += 2) {
+                bytes.push(parseInt(clean.substr(i, 2), 16));
+            }
+            return new Uint8Array(bytes);
         }
-        // TODO: handle data length > 16
 
-        let DevModeRef = message.getUint8(start);
-        let DevStatus = message.getUint8(start+1);
-        let UniqueID = message.getUint16(start+2);
-
-        // Create an ArrayBuffer with enough space to hold the measurements (4 bytes
-        // Create a DataView from the ArrayBuffer
-        let resultDataView = new DataView(new ArrayBuffer(4));
-        let component1DataView = new DataView(new ArrayBuffer(4));
-        let component2DataView = new DataView(new ArrayBuffer(4));
-
-
-
-        // Loop over the measurement bytes in the DataView
-        for (let i = start+4; i < start+8; i++) {
-            // Get the byte as an unsigned 8-bit integer
-            let byte = message.getUint8(i);
-            resultDataView.setUint8(i - 4-start, byte);
-        }
-        for (let i = start+8; i < start+12; i++) {
-            let byte = message.getUint8(i);
-            component1DataView.setUint8(i - 8-start, byte);
-        }
-        for (let i = start+12; i < start+16; i++) {
-            let byte = message.getUint8(i);
-            component2DataView.setUint8(i - 12-start, byte);
+        async function sendExplorerCommand() {
+            const cmd = parseInt($('cmd-hex').value.trim(), 16);
+            if (isNaN(cmd)) { log('Error: invalid command', 'err'); return; }
+            const payload = $('cmd-payload').value.trim() ? parseHexBytes($('cmd-payload').value.trim()) : undefined;
+            try {
+                await device.sendCommand(cmd, payload);
+                const payloadStr = payload ? ` [${Array.from(payload).map(b => b.toString(16).padStart(2, '0')).join(' ')}]` : '';
+                log(`TX: cmd 0x${cmd.toString(16).padStart(2, '0')}${payloadStr}`, 'tx');
+            } catch (err) {
+                log(`Error: ${err.message}`, 'err');
+            }
         }
 
-        return {
-            DevModeRef,
-            DevModeRefHex: DevModeRef.toString(16),
-            DevModeRefBin: DevModeRef.toString(2),
-            DevMode: DevModeRef>>2,
-            ReferenceEdge: DevModeRef & 11,
-            DevStatus,
-            DevStatusHex: DevStatus.toString(16),
-            DevStatusBin: DevStatus.toString(2),
-            MetricSystem: (DevStatus & 0b1000) !== 0,
-            LowBatteryWarning: (DevStatus & 0b0100) !== 0,
-            TemperatureWarning: (DevStatus & 0b0010) !== 0,
-            LaserStatus: (DevStatus & 0b0001) !== 0,
-            UniqueID,
-            UniqueIDHex: UniqueID.toString(16),
-            UniqueIDBin: UniqueID.toString(2),
-            result : resultDataView.getFloat32(0, true),
-            component1 : component1DataView.getFloat32(0, true),
-            component2 : component2DataView.getFloat32(0, true)
-        };
-      }
+        $('cmd-send-btn').addEventListener('click', sendExplorerCommand);
 
-      function dataViewToString(dataView) {
-        let hexString = "";
-        for (let i = 0; i < dataView.byteLength; i++) {
-          let byte = dataView.getUint8(i);
-          hexString += byte.toString(16).padStart(2, "0");
+        // --- Scan ---
+        let scanAbort = false;
+
+        $('scan-stop-btn').addEventListener('click', () => { scanAbort = true; });
+
+        $('scan-cmd-btn').addEventListener('click', async () => {
+            const cmd = parseInt($('scan-cmd').value.trim(), 16);
+            if (isNaN(cmd)) { log('Error: invalid command', 'err'); return; }
+
+            const btn = $('scan-cmd-btn');
+            const stopBtn = $('scan-stop-btn');
+            const results = $('scan-results');
+            btn.disabled = true;
+            stopBtn.classList.remove('hidden');
+            scanAbort = false;
+            results.textContent = `Scanning CMD 0x${cmd.toString(16).padStart(2, '0')} with payload 0x00→0xFF...\n\n`;
+
+            const responseMap = new Map();
+
+            for (let val = 0; val <= 0xff && !scanAbort; val++) {
+                const hex = val.toString(16).padStart(2, '0');
+                try {
+                    // Capture the raw response
+                    // Reset busy flag before each scan step
+                    device._busy = false;
+
+                    const response = await new Promise((resolve) => {
+                        const timeout = setTimeout(() => { cleanup(); resolve('timeout'); }, 1500);
+                        const originalOnRaw = device._events.onRawFrame;
+                        let captured = false;
+
+                        device._events.onRawFrame = (message, rxHex) => {
+                            originalOnRaw(message, rxHex);
+                            if (!captured) {
+                                captured = true;
+                                cleanup();
+                                resolve(rxHex);
+                            }
+                        };
+
+                        const cleanup = () => {
+                            clearTimeout(timeout);
+                            device._events.onRawFrame = originalOnRaw;
+                        };
+
+                        device.sendCommand(cmd, new Uint8Array([val])).catch(() => {
+                            cleanup();
+                            resolve('send_error');
+                        });
+                    });
+
+                    // Group by response
+                    if (!responseMap.has(response)) {
+                        responseMap.set(response, []);
+                    }
+                    responseMap.get(response).push(val);
+
+                    results.textContent += `0x${hex} → ${response}\n`;
+                    results.scrollTop = results.scrollHeight;
+                } catch (err) {
+                    results.textContent += `0x${hex} → error: ${err.message}\n`;
+                }
+
+                await new Promise(r => setTimeout(r, 200));
+            }
+
+            // Summary
+            results.textContent += `\n--- Summary (CMD 0x${cmd.toString(16).padStart(2, '0')}) ---\n`;
+            for (const [resp, vals] of responseMap) {
+                const ranges = compactRanges(vals);
+                results.textContent += `${resp}: ${ranges}\n`;
+            }
+
+            btn.disabled = false;
+            stopBtn.classList.add('hidden');
+        });
+
+        // Compact [0,1,2,5,6,10] → "0x00-0x02, 0x05-0x06, 0x0a"
+        function compactRanges(values) {
+            if (values.length === 0) return '';
+            const sorted = [...values].sort((a, b) => a - b);
+            const ranges = [];
+            let start = sorted[0], end = sorted[0];
+            for (let i = 1; i < sorted.length; i++) {
+                if (sorted[i] === end + 1) {
+                    end = sorted[i];
+                } else {
+                    ranges.push(start === end
+                        ? `0x${start.toString(16).padStart(2, '0')}`
+                        : `0x${start.toString(16).padStart(2, '0')}-0x${end.toString(16).padStart(2, '0')}`);
+                    start = end = sorted[i];
+                }
+            }
+            ranges.push(start === end
+                ? `0x${start.toString(16).padStart(2, '0')}`
+                : `0x${start.toString(16).padStart(2, '0')}-0x${end.toString(16).padStart(2, '0')}`);
+            return ranges.join(', ');
         }
-        return hexString;
-      }
+
+        $('clear-history-btn').addEventListener('click', () => {
+            historyBody.innerHTML = '';
+            measurementCount = 0;
+            measurementResult.innerHTML = '—';
+            measurementDetails.innerHTML = '';
+        });
+
+        $('clear-log-btn').addEventListener('click', () => { rawLog.innerHTML = ''; });
+
+        function log(text, cls = '') {
+            const line = document.createElement('div');
+            if (cls) line.className = cls;
+            line.textContent = `[${new Date().toLocaleTimeString()}] ${text}`;
+            rawLog.prepend(line);
+            while (rawLog.children.length > 200) rawLog.removeChild(rawLog.lastChild);
+        }
+
+        if (!navigator.bluetooth) {
+            $('warning').style.display = 'block';
+            connectBtn.disabled = true;
+        }
     </script>
-  </body>
+</body>
 </html>

--- a/app/js/device.js
+++ b/app/js/device.js
@@ -1,0 +1,275 @@
+/**
+ * Bosch PLR/GLM BLE Device Manager
+ *
+ * Handles connection, command sending, and indication processing.
+ * Tested with Bosch PLR 50C.
+ */
+import {
+    GLM_SERVICE_UUID,
+    TX_CHARACTERISTIC_UUID,
+    CMD_MEASURE,
+    CMD_LASER_ON,
+    CMD_LASER_OFF,
+    CMD_BEEP_ON,
+    CMD_BEEP_OFF,
+    CMD_BACKLIGHT_ON,
+    CMD_BACKLIGHT_OFF,
+    CMD_EXCHANGE_DATA,
+    CMD_CLEAR_MEASUREMENTS,
+    CMD_DEVICE_INFO,
+    FORMAT_LONG,
+    FORMAT_SHORT,
+    buildCommand,
+    verifyChecksum,
+    parseFrameHeader,
+    parseShortFrameStatus,
+    parseMeasurementData,
+    toHex,
+} from './protocol.js';
+
+export class BoschDevice {
+    /** @type {BluetoothRemoteGATTServer | null} */
+    _server = null;
+    /** @type {BluetoothRemoteGATTCharacteristic | null} */
+    _characteristic = null;
+    /** @type {BluetoothDevice | null} */
+    _device = null;
+    /** @type {object} */
+    _events = {};
+    /** @type {boolean} */
+    _busy = false;
+
+    /**
+     * @param {object} events
+     * @param {function} [events.onMeasurement] - Called with parsed measurement data
+     * @param {function} [events.onStatus] - Called with parsed short frame status
+     * @param {function} [events.onStatusChange] - Called with (state, message)
+     * @param {function} [events.onRawFrame] - Called with (DataView, hex string)
+     */
+    constructor(events = {}) {
+        this._events = events;
+    }
+
+    get connected() {
+        return this._server?.connected ?? false;
+    }
+
+    get deviceName() {
+        return this._device?.name ?? null;
+    }
+
+    /**
+     * Pair with a Bosch PLR/GLM device via Web Bluetooth.
+     * @returns {Promise<string>} Device name
+     */
+    async connect() {
+        this._emit('onStatusChange', 'connecting', 'Scanning for device…');
+
+        const device = await navigator.bluetooth.requestDevice({
+            filters: [
+                { namePrefix: 'Bosch PLR' },
+                { namePrefix: 'Bosch GLM' },
+                { services: [GLM_SERVICE_UUID] },
+            ],
+            optionalServices: [TX_CHARACTERISTIC_UUID],
+        });
+
+        this._device = device;
+        this._emit('onStatusChange', 'connecting', `Connecting to ${device.name}…`);
+
+        device.addEventListener('gattserverdisconnected', () => this._onDisconnect());
+
+        const server = await device.gatt.connect();
+        this._server = server;
+
+        const service = await server.getPrimaryService(GLM_SERVICE_UUID);
+        this._characteristic = await service.getCharacteristic(TX_CHARACTERISTIC_UUID);
+
+        await this._characteristic.startNotifications();
+        this._characteristic.addEventListener('characteristicvaluechanged', (e) =>
+            this._onIndication(e),
+        );
+
+        // Enable AutoSync: device sends measurements automatically
+        await this._send(CMD_EXCHANGE_DATA, new Uint8Array([0x01, 0x00]));
+
+        this._emit('onStatusChange', 'connected', device.name);
+        return device.name;
+    }
+
+    disconnect() {
+        if (this._server?.connected) {
+            this._server.disconnect();
+        }
+        this._cleanup();
+        this._emit('onStatusChange', 'disconnected', 'Disconnected');
+    }
+
+    // --- Commands ---
+
+    /**
+     * Trigger a distance measurement.
+     * Note: always returns distance regardless of device mode.
+     * For angle/area/volume, use the device button — results sync via AutoSync.
+     * @param {number} [edge=0x00] - Reference edge (0=back, 1=front, 2=side)
+     */
+    async measure(edge = 0x00) {
+        await this._send(CMD_MEASURE, new Uint8Array([edge]));
+    }
+
+    async laserOn() {
+        await this._send(CMD_LASER_ON, new Uint8Array([0x00]));
+    }
+
+    async laserOff() {
+        await this._send(CMD_LASER_OFF, new Uint8Array([0x00]));
+    }
+
+    /**
+     * @param {number} [durationMs=500]
+     */
+    async beep(durationMs = 500) {
+        await this._send(CMD_BEEP_ON, new Uint8Array([0x00]));
+        await new Promise((r) => setTimeout(r, durationMs));
+        this._busy = false;
+        await this._send(CMD_BEEP_OFF, new Uint8Array([0x00]));
+    }
+
+    async backlightOn() {
+        await this._send(CMD_BACKLIGHT_ON, new Uint8Array([0x00]));
+    }
+
+    async backlightOff() {
+        await this._send(CMD_BACKLIGHT_OFF, new Uint8Array([0x00]));
+    }
+
+    /**
+     * Change device mode via Exchange Data Container (CMD 0x55).
+     * DevModeSync byte: Bit[7..2]=DevMode(60=SetDevAppMode), Bit[0]=AutoSync
+     * RemoteCtrlData byte: target mode
+     * @param {number} mode - 1=Distance, 2=Area, 4=Angle, 7=Volume, 8=IndirectHeight, etc.
+     */
+    async changeMode(mode) {
+        const devModeSync = (60 << 2) | 0x01; // DevMode=60(SetDevAppMode) + AutoSync=1
+        await this._send(CMD_EXCHANGE_DATA, new Uint8Array([devModeSync, mode]));
+    }
+
+    /**
+     * Set distance reference via Exchange Data Container.
+     * @param {number} ref - 0=Front, 1=Tripod, 2=Rear
+     */
+    async setDistanceReference(ref) {
+        const devModeSync = (62 << 2) | 0x01; // DevMode=62(SetDistanceReference) + AutoSync
+        await this._send(CMD_EXCHANGE_DATA, new Uint8Array([devModeSync, ref]));
+    }
+
+    async clearMeasurements() {
+        await this._send(CMD_CLEAR_MEASUREMENTS);
+    }
+
+    async requestDeviceInfo() {
+        await this._send(CMD_DEVICE_INFO);
+    }
+
+    /**
+     * Send a raw command for protocol exploration.
+     * @param {number} command
+     * @param {Uint8Array} [data]
+     */
+    async sendCommand(command, data) {
+        await this._send(command, data);
+    }
+
+    // --- Private ---
+
+    async _send(command, data) {
+        if (!this._characteristic) {
+            throw new Error('Not connected');
+        }
+        if (this._busy) {
+            throw new Error('Command in progress, please wait');
+        }
+        this._busy = true;
+        try {
+            const frame = buildCommand(command, data);
+            await this._characteristic.writeValueWithResponse(frame);
+        } finally {
+            this._busy = false;
+        }
+    }
+
+    _onIndication(event) {
+        const message = event.target.value;
+        const hex = toHex(message);
+
+        this._emit('onRawFrame', message, hex);
+
+        const header = parseFrameHeader(message);
+        if (header.isInvalid) return;
+
+        if (
+            (header.isRequest && header.requestFormat === FORMAT_SHORT) ||
+            (header.isResponse && header.responseFormat === FORMAT_SHORT)
+        ) {
+            this._emit('onStatus', parseShortFrameStatus(message));
+            return;
+        }
+
+        if (header.isRequest && header.requestFormat === FORMAT_LONG) {
+            this._handleLongRequest(message);
+        } else if (header.isResponse && header.responseFormat === FORMAT_LONG) {
+            this._handleLongResponse(message);
+        }
+    }
+
+    _handleLongRequest(message) {
+        if (!verifyChecksum(message)) return;
+
+        const command = message.getUint8(1);
+        const dataLength = message.getUint8(2);
+
+        if (command === CMD_EXCHANGE_DATA && dataLength > 0) {
+            const data = parseMeasurementData(message, 3, dataLength);
+            if (data) {
+                this._emit('onMeasurement', { source: 'device', ...data });
+            }
+            return;
+        }
+
+        if (dataLength > 0) {
+            const data = parseMeasurementData(message, 3, dataLength);
+            if (data) {
+                this._emit('onMeasurement', { source: 'device', ...data });
+            }
+        }
+    }
+
+    _handleLongResponse(message) {
+        if (!verifyChecksum(message)) return;
+
+        const dataLength = message.getUint8(1);
+        if (dataLength === 0) return;
+
+        const data = parseMeasurementData(message, 2, dataLength);
+        if (data) {
+            this._emit('onMeasurement', { source: 'browser', ...data });
+        }
+    }
+
+    _onDisconnect() {
+        this._cleanup();
+        this._emit('onStatusChange', 'disconnected', 'Device disconnected');
+    }
+
+    _cleanup() {
+        this._server = null;
+        this._characteristic = null;
+        this._device = null;
+    }
+
+    _emit(eventName, ...args) {
+        if (typeof this._events[eventName] === 'function') {
+            this._events[eventName](...args);
+        }
+    }
+}

--- a/app/js/protocol.js
+++ b/app/js/protocol.js
@@ -1,0 +1,344 @@
+/**
+ * Bosch PLR/GLM MT Connectivity Protocol
+ *
+ * Reference: MT_connectivity_protocol_1_2_9.pdf
+ *            MT_connectivity_protocol_LRF_command_set_2_5_0.pdf
+ */
+
+// BLE identifiers
+export const GLM_SERVICE_UUID = '00005301-0000-0041-5253-534f46540000';
+export const TX_CHARACTERISTIC_UUID = '00004301-0000-0041-5253-534f46540000';
+
+// Frame types (bits 6-7 of mode byte)
+export const FRAME_TYPE_RESPONSE = 0b00;
+export const FRAME_TYPE_REQUEST = 0b11;
+
+// Frame formats
+export const FORMAT_LONG = 0b00;
+export const FORMAT_SHORT = 0b01;
+
+// Commands
+export const CMD_MEASURE = 0x40;
+export const CMD_LASER_ON = 0x41;
+export const CMD_LASER_OFF = 0x42;
+export const CMD_BEEP_ON = 0x45;
+export const CMD_BEEP_OFF = 0x46;
+export const CMD_BACKLIGHT_ON = 0x47;
+export const CMD_BACKLIGHT_OFF = 0x48;
+export const CMD_GET_MEASUREMENTS = 0x51;
+export const CMD_CLEAR_MEASUREMENTS = 0x52;
+export const CMD_EXCHANGE_DATA = 0x55;
+export const CMD_DEVICE_INFO = 0x3a;
+
+// Reference edges for CMD_MEASURE payload (bits 6-7)
+// Doc says: 0=Front, 1=Tripod, 2=Rear, 3=Pin
+// PLR 50C: 0x40 and 0x80 both return rear distance, 0xC0 returns tripod
+export const EDGE_FRONT = 0x00;  // 0b00xxxxxx → front of device
+export const EDGE_REAR = 0x80;   // 0b10xxxxxx → rear of device
+export const EDGE_TRIPOD = 0xc0; // 0b11xxxxxx → tripod mount
+
+// Device modes as reported in 16-byte measurement blocks (devModeRef >> 2)
+export const DEVICE_MODES = {
+    1: 'Distance',
+    2: 'Continuous',
+    3: 'Area (partial)',
+    4: 'Area',
+    5: 'Volume (partial)',
+    6: 'Volume (partial)',
+    7: 'Volume',
+    8: 'Angle',
+};
+
+// Distance reference (bits 0-1 of devModeRef)
+export const DISTANCE_REFERENCES = {
+    0: 'Back',
+    1: 'Front',
+    2: 'Tripod',
+};
+
+// Short response status codes (bits 0-2)
+export const STATUS_CODES = {
+    0x00: 'Success',
+    0x01: 'Communication timeout',
+    0x02: 'Mode not supported',
+    0x03: 'Checksum error',
+    0x04: 'Command unknown',
+    0x05: 'Access level invalid',
+    0x06: 'Parameter invalid',
+};
+
+// CRC-8 lookup table (polynomial 0xA6, init 0xAA)
+// prettier-ignore
+const CRC_TABLE = new Uint8Array([
+    0x00, 0xA6, 0xEA, 0x4C, 0x72, 0xD4, 0x98, 0x3E, 0xE4, 0x42, 0x0E, 0xA8, 0x96, 0x30, 0x7C, 0xDA,
+    0x6E, 0xC8, 0x84, 0x22, 0x1C, 0xBA, 0xF6, 0x50, 0x8A, 0x2C, 0x60, 0xC6, 0xF8, 0x5E, 0x12, 0xB4,
+    0xDC, 0x7A, 0x36, 0x90, 0xAE, 0x08, 0x44, 0xE2, 0x38, 0x9E, 0xD2, 0x74, 0x4A, 0xEC, 0xA0, 0x06,
+    0xB2, 0x14, 0x58, 0xFE, 0xC0, 0x66, 0x2A, 0x8C, 0x56, 0xF0, 0xBC, 0x1A, 0x24, 0x82, 0xCE, 0x68,
+    0x1E, 0xB8, 0xF4, 0x52, 0x6C, 0xCA, 0x86, 0x20, 0xFA, 0x5C, 0x10, 0xB6, 0x88, 0x2E, 0x62, 0xC4,
+    0x70, 0xD6, 0x9A, 0x3C, 0x02, 0xA4, 0xE8, 0x4E, 0x94, 0x32, 0x7E, 0xD8, 0xE6, 0x40, 0x0C, 0xAA,
+    0xC2, 0x64, 0x28, 0x8E, 0xB0, 0x16, 0x5A, 0xFC, 0x26, 0x80, 0xCC, 0x6A, 0x54, 0xF2, 0xBE, 0x18,
+    0xAC, 0x0A, 0x46, 0xE0, 0xDE, 0x78, 0x34, 0x92, 0x48, 0xEE, 0xA2, 0x04, 0x3A, 0x9C, 0xD0, 0x76,
+    0x3C, 0x9A, 0xD6, 0x70, 0x4E, 0xE8, 0xA4, 0x02, 0xD8, 0x7E, 0x32, 0x94, 0xAA, 0x0C, 0x40, 0xE6,
+    0x52, 0xF4, 0xB8, 0x1E, 0x20, 0x86, 0xCA, 0x6C, 0xB6, 0x10, 0x5C, 0xFA, 0xC4, 0x62, 0x2E, 0x88,
+    0xE0, 0x46, 0x0A, 0xAC, 0x92, 0x34, 0x78, 0xDE, 0x04, 0xA2, 0xEE, 0x48, 0x76, 0xD0, 0x9C, 0x3A,
+    0x8E, 0x28, 0x64, 0xC2, 0xFC, 0x5A, 0x16, 0xB0, 0x6A, 0xCC, 0x80, 0x26, 0x18, 0xBE, 0xF2, 0x54,
+    0x22, 0x84, 0xC8, 0x6E, 0x50, 0xF6, 0xBA, 0x1C, 0xC6, 0x60, 0x2C, 0x8A, 0xB4, 0x12, 0x5E, 0xF8,
+    0x4C, 0xEA, 0xA6, 0x00, 0x3E, 0x98, 0xD4, 0x72, 0xA8, 0x0E, 0x42, 0xE4, 0xDA, 0x7C, 0x30, 0x96,
+    0xFE, 0x58, 0x14, 0xB2, 0x8C, 0x2A, 0x66, 0xC0, 0x1A, 0xBC, 0xF0, 0x56, 0x68, 0xCE, 0x82, 0x24,
+    0x90, 0x36, 0x7A, 0xDC, 0xE2, 0x44, 0x08, 0xAE, 0x74, 0xD2, 0x9E, 0x38, 0x06, 0xA0, 0xEC, 0x4A,
+]);
+
+/**
+ * Compute CRC-8 checksum (polynomial 0xA6, init 0xAA).
+ * @param {Uint8Array} buffer
+ * @returns {number}
+ */
+export function crc8(buffer) {
+    let crc = 0xaa;
+    for (let i = 0; i < buffer.length; i++) {
+        crc = CRC_TABLE[(crc ^ buffer[i]) & 0xff];
+    }
+    return crc;
+}
+
+/**
+ * Verify the CRC-8 checksum of a received frame.
+ * @param {DataView} message
+ * @returns {boolean}
+ */
+export function verifyChecksum(message) {
+    const payload = new Uint8Array(message.buffer, message.byteOffset, message.byteLength - 1);
+    const calculated = crc8(payload);
+    const received = message.getUint8(message.byteLength - 1);
+    return calculated === received;
+}
+
+/**
+ * Build a command frame with CRC-8 checksum.
+ * @param {number} command
+ * @param {Uint8Array} [data]
+ * @returns {Uint8Array}
+ */
+export function buildCommand(command, data) {
+    const hasData = data && data.length > 0;
+    const frameLength = hasData ? 3 + data.length + 1 : 4; // mode + cmd + len + [data] + crc
+    const frame = new Uint8Array(frameLength);
+
+    frame[0] = 0xc0; // mode: request, long format
+    frame[1] = command;
+    frame[2] = hasData ? data.length : 0x00;
+
+    if (hasData) {
+        frame.set(data, 3);
+    }
+
+    frame[frameLength - 1] = crc8(frame.subarray(0, frameLength - 1));
+    return frame;
+}
+
+/**
+ * Convert a DataView to a hex string.
+ * @param {DataView} dataView
+ * @returns {string}
+ */
+export function toHex(dataView) {
+    let hex = '';
+    for (let i = 0; i < dataView.byteLength; i++) {
+        hex += dataView.getUint8(i).toString(16).padStart(2, '0');
+    }
+    return hex;
+}
+
+/**
+ * Parse frame header to extract type and format info.
+ * @param {DataView} message
+ * @returns {object}
+ */
+export function parseFrameHeader(message) {
+    const mode = message.getUint8(0);
+    const frameType = mode >> 6;
+    const requestFormat = (mode & 0b00001100) >> 2;
+    const responseFormat = mode & 0b00000011;
+
+    return {
+        frameType,
+        requestFormat,
+        responseFormat,
+        isRequest: frameType === FRAME_TYPE_REQUEST,
+        isResponse: frameType === FRAME_TYPE_RESPONSE,
+        isInvalid: frameType === 0b01 || frameType === 0b10,
+    };
+}
+
+/**
+ * Parse a short response/request frame status byte.
+ *
+ * Short frame format: [mode][status][crc]
+ * Status byte layout:
+ *   bits 0-2: status code (see STATUS_CODES)
+ *   bit 3:    hardware error
+ *   bit 4:    not ready
+ *   bit 5:    hand raised
+ *
+ * @param {DataView} message
+ * @returns {object}
+ */
+export function parseShortFrameStatus(message) {
+    const status = message.getUint8(1);
+    const statusCode = status & 0x07;
+
+    return {
+        statusCode,
+        statusMessage: STATUS_CODES[statusCode] || `Unknown (${statusCode})`,
+        isSuccess: statusCode === 0x00,
+        hardwareError: !!(status & 0x08),
+        notReady: !!(status & 0x10),
+        handRaised: !!(status & 0x20),
+    };
+}
+
+/**
+ * Parse a GLMSyncContainer from the Exchange Data Container response.
+ *
+ * The sync container is sent by the device when AutoSync is enabled and
+ * the user triggers a measurement on the device itself.
+ *
+ * Layout (33 bytes):
+ *   [0]     measurement type (bits 0-4), calc indicator (bits 5-7)
+ *   [1]     distance ref (bits 0-2), angle ref (bits 3-5), distance unit (bit 6)
+ *   [2]     battery state of charge (%)
+ *   [3]     temperature (°C, signed)
+ *   [4-7]   distance 1 (float32 LE, meters)
+ *   [8-11]  distance 2 (float32 LE, meters)
+ *   [12-15] distance 3 (float32 LE, meters)
+ *   [16-19] result (float32 LE, meters)
+ *   [20-23] angle (float32 LE, degrees)
+ *   [24-27] timestamp (uint32 LE)
+ *   [28]    laser on (bit 0), usability errors (bits 1-7)
+ *   [29]    measurement list index
+ *   [30-31] compass heading (int16 LE, degrees)
+ *   [32]    NDOF sensor status
+ *
+ * @param {DataView} message
+ * @param {number} dataOffset
+ * @returns {object}
+ */
+export function parseSyncContainer(message, dataOffset) {
+    const byte0 = message.getUint8(dataOffset);
+    const byte1 = message.getUint8(dataOffset + 1);
+
+    const measurementTypeId = byte0 & 0x1f;
+    const calcIndicator = (byte0 >> 5) & 0x07;
+    const distanceRef = byte1 & 0x07;
+    const angleRef = (byte1 >> 3) & 0x07;
+    const distanceUnit = (byte1 >> 6) & 0x01;
+
+    const battery = message.getUint8(dataOffset + 2);
+    const temperature = message.getInt8(dataOffset + 3);
+
+    const distance1 = readFloat32(message, dataOffset + 4);
+    const distance2 = readFloat32(message, dataOffset + 8);
+    const distance3 = readFloat32(message, dataOffset + 12);
+    const result = readFloat32(message, dataOffset + 16);
+    const angle = readFloat32(message, dataOffset + 20);
+    const timestamp = message.getUint32(dataOffset + 24, true);
+
+    const byte28 = message.getUint8(dataOffset + 28);
+    const laserOn = !!(byte28 & 0x01);
+    const errors = byte28 >> 1;
+
+    const measurementIndex = message.getUint8(dataOffset + 29);
+    const compassHeading = message.getInt16(dataOffset + 30, true);
+    const ndofStatus = message.getUint8(dataOffset + 32);
+
+    return {
+        measurementType: DEVICE_MODES[measurementTypeId] || `Unknown (${measurementTypeId})`,
+        measurementTypeId,
+        calcIndicator,
+        distanceReference: DISTANCE_REFERENCES[distanceRef] || `Unknown (${distanceRef})`,
+        distanceRefId: distanceRef,
+        angleRef,
+        distanceUnit: distanceUnit === 0 ? 'Metric' : 'Imperial',
+        battery,
+        temperature,
+        distance1,
+        distance2,
+        distance3,
+        result,
+        angle,
+        timestamp,
+        laserOn,
+        errors,
+        measurementIndex,
+        compassHeading,
+        ndofStatus,
+    };
+}
+
+/**
+ * Parse a measurement result from a long request/response frame.
+ *
+ * 4-byte response (CMD_MEASURE reply):
+ *   uint32 LE distance in 0.05mm units
+ *
+ * 16-byte data block (AutoSync measurement):
+ *   [0]     DevModeRef: mode (bits 2-7), reference edge (bits 0-1)
+ *   [1]     DevStatus: metric (bit 3), low battery (bit 2), temp warning (bit 1), laser (bit 0)
+ *   [2-3]   UniqueID (uint16 LE)
+ *   [4-7]   result (float32 LE)
+ *   [8-11]  component1 (float32 LE) — intermediate side or first side
+ *   [12-15] component2 (float32 LE) — second side (area) or unused
+ *
+ * @param {DataView} message
+ * @param {number} dataOffset
+ * @param {number} dataLength
+ * @returns {object | null}
+ */
+export function parseMeasurementData(message, dataOffset, dataLength) {
+    if (dataLength === 0) return null;
+
+    // 4-byte response: uint32 LE distance in 0.05mm units
+    if (dataLength === 4) {
+        const raw = message.getUint32(dataOffset, true);
+        return { result: (raw * 0.05) / 1000 }; // convert to meters
+    }
+
+    // 16-byte measurement block with device status
+    if (dataLength >= 16) {
+        const devModeRef = message.getUint8(dataOffset);
+        const devStatus = message.getUint8(dataOffset + 1);
+        const uniqueId = message.getUint16(dataOffset + 2, true);
+
+        const modeId = devModeRef >> 2;
+        return {
+            mode: modeId,
+            measurementType: DEVICE_MODES[modeId] || `Unknown (${modeId})`,
+            referenceEdge: devModeRef & 0x03,
+            distanceReference: DISTANCE_REFERENCES[devModeRef & 0x03],
+            metricSystem: !!(devStatus & 0x08),
+            lowBattery: !!(devStatus & 0x04),
+            temperatureWarning: !!(devStatus & 0x02),
+            laserOn: !!(devStatus & 0x01),
+            uniqueId,
+            result: readFloat32(message, dataOffset + 4),
+            component1: readFloat32(message, dataOffset + 8),
+            component2: readFloat32(message, dataOffset + 12),
+        };
+    }
+
+    return null;
+}
+
+/**
+ * Read a little-endian float32 from a DataView.
+ * @param {DataView} view
+ * @param {number} offset
+ * @returns {number}
+ */
+function readFloat32(view, offset) {
+    const buf = new DataView(new ArrayBuffer(4));
+    for (let i = 0; i < 4; i++) {
+        buf.setUint8(i, view.getUint8(offset + i));
+    }
+    return buf.getFloat32(0, true);
+}


### PR DESCRIPTION
Fixes #2

## Summary

- **Fix measurement parsing**: `CMD_MEASURE` (0x40) response uses `uint32 LE` in 0.05mm units, not float32
- **Fix frame building**: commands without payload need 4 bytes `[mode, cmd, len=0, crc]` — CRC was overwriting length byte
- **Fix edge reference**: bits 6-7 of CMD 0x40 payload (0=Front, 1=Tripod, 2=Rear, 3=Pin)
- **Fix AutoSync**: 16-byte measurement blocks correctly parsed with proper mode ID mapping
- **Add all measurement types**: distance, continuous, area, volume, angle with correct units (m, m², m³, °)
- **Add side measurements**: area/volume results show individual side values
- **Add laser flash, beep on/off, backlight on/off** controls
- **Add busy guard** to prevent "GATT operation already in progress" errors
- **Add command explorer** with full 0x00–0xFF scan for protocol research
- **Extract JS** into separate modules (`protocol.js`, `device.js`)

## PLR 50C Protocol Findings

| CMD | Function | Status |
|-----|----------|--------|
| 0x40 | Measure distance (bits 6-7 = edge ref) | Works |
| 0x41 | Laser flash | Works |
| 0x42 | Laser off | Works |
| 0x45/0x46 | Buzzer on/off | Works |
| 0x47/0x48 | Backlight on/off | Works |
| 0x52 | Clear measurements | Works |
| 0x55 `[01 00]` | AutoSync (receive all measurement types) | Works |
| 0x55 `[F1 xx]` | Change mode (SetDevAppMode) | Not supported |
| 0x56 | Remote trigger button | Not supported |
| 0x60 | Change mode (legacy) | Not supported |